### PR TITLE
Fix crash when parsing command at end of message

### DIFF
--- a/telebot/utils.nim
+++ b/telebot/utils.nim
@@ -27,12 +27,16 @@ proc getCommands*(update: Update): StringTableRef =
       var entities = message.entities.get()
       for entity in entities:
         if entity.kind == "bot_command":
-          var messageText = message.text.get()
-          var command = message_text[(entity.offset + 1)..<entity.length].strip()
+          var 
+            messageText = message.text.get()
+            offset = entity.offset
+            length = entity.length
+            command = message_text[(offset + 1)..<(offset + length)].strip()
+
           if '@' in command:
             command = command.split('@')[0]
 
-          var param = message_text[(entity.offset + entity.length)..^1]
+          var param = message_text[(offset + length)..^1]
           param = param.split(Whitespace, 0).join().strip()
           result[command] = param
 


### PR DESCRIPTION
When parsing a message like the following:
`nim can target C/C++/JS`
or `. /start`
Nim spits out an exception:
```
Exception message: value out of range: -18
Exception type: [RangeError]
```

For some reason, Telegram allows commands anywhere in a message after a non-alphanumeric character, but the offset isn't taken into consideration. 