### PR TITLE
Add missing message editing endpoints

### DIFF
--- a/telebot.nimble
+++ b/telebot.nimble
@@ -1,4 +1,4 @@
-version       = "0.4.2"
+version       = "0.5.0"
 author        = "Huy Doan"
 description   = "Async Telegram Bot API Client"
 license       = "MIT"

--- a/telebot/api.nim
+++ b/telebot/api.nim
@@ -467,7 +467,7 @@ proc sendMediaGroup*(b: TeleBot, chatId = "", media: seq[InputMedia], disableNot
   let res = await makeRequest(endpoint % b.token, data)
   result = res.bval
 
-proc editMessageMedia*(b: TeleBot, media: InputMedia, chatId = "", messageId = 0, inlineMessageId = 0, replyMarkup: KeyboardMarkup = nil): Future[bool] {.async.} =
+proc editMessageMedia*(b: TeleBot, media: InputMedia, chatId = "", messageId = 0, inlineMessageId = 0, replyMarkup: KeyboardMarkup = nil): Future[Option[Message]] {.async.} =
   END_POINT("editMessageMedia")
   var data = newMultipartData()
   if chatId.len > 0:
@@ -483,6 +483,82 @@ proc editMessageMedia*(b: TeleBot, media: InputMedia, chatId = "", messageId = 0
   data["media"] = json
   if replyMarkup != nil:
     data["reply_markup"] = $replyMarkup
+
+  let res = await makeRequest(endpoint % b.token, data)
+  if res.kind == JBool:
+    result = none(Message)
+  else:
+    result = some(unmarshal(res, Message))
+
+proc editMessageText*(b: TeleBot, text: string, chatId = "", messageId = 0, inlineMessageId = 0, parseMode="", replyMarkup: KeyboardMarkup = nil, disableWebPagePreview=false): Future[Option[Message]] {.async.} =
+  END_POINT("editMessageText")
+  var data = newMultipartData()
+  if chatId.len > 0:
+    data["chat_id"] = chat_id
+  if messageId != 0:
+    data["message_id"] = $messageId
+  if inlineMessageId != 0:
+    data["inline_message_id"] = $inlineMessageId
+  if replyMarkup != nil:
+    data["reply_markup"] = $replyMarkup
+  if parseMode != "":
+    data["parse_mode"] = parseMode
+  if disableWebPagePreview == true:
+    data["disable_web_page_preview"] = "true"
+
+  data["text"] = text
+
+  let res = await makeRequest(endpoint % b.token, data)
+  if res.kind == JBool:
+    result = none(Message)
+  else:
+    result = some(unmarshal(res, Message))
+
+proc editMessageCaption*(b: TeleBot, caption = "", chatId = "", messageId = 0, inlineMessageId = 0, parseMode="", replyMarkup: KeyboardMarkup = nil): Future[Option[Message]] {.async.} =
+  END_POINT("editMessageCaption")
+  var data = newMultipartData()
+  if chatId.len > 0:
+    data["chat_id"] = chat_id
+  if messageId != 0:
+    data["message_id"] = $messageId
+  if inlineMessageId != 0:
+    data["inline_message_id"] = $inlineMessageId
+  if replyMarkup != nil:
+    data["reply_markup"] = $replyMarkup
+  if parseMode != "":
+    data["parse_mode"] = parseMode
+
+  data["caption"] = caption
+
+  let res = await makeRequest(endpoint % b.token, data)
+  if res.kind == JBool:
+    result = none(Message)
+  else:
+    result = some(unmarshal(res, Message))
+
+proc editMessageReplyMarkup*(b: TeleBot, chatId = "", messageId = 0, inlineMessageId = 0, replyMarkup: KeyboardMarkup = nil): Future[Option[Message]] {.async.} =
+  END_POINT("editMessageReplyMarkup")
+  var data = newMultipartData()
+  if chatId.len > 0:
+    data["chat_id"] = chat_id
+  if messageId != 0:
+    data["message_id"] = $messageId
+  if inlineMessageId != 0:
+    data["inline_message_id"] = $inlineMessageId
+  if replyMarkup != nil:
+    data["reply_markup"] = $replyMarkup
+
+  let res = await makeRequest(endpoint % b.token, data)
+  if res.kind == JBool:
+    result = none(Message)
+  else:
+    result = some(unmarshal(res, Message))
+
+proc deleteMessage*(b: Telebot, chatId: string, messageId: int): Future[bool] {.async.} =
+  END_POINT("deleteMessage")
+  var data = newMultipartData()
+  data["chat_id"] = chat_id
+  data["message_id"] = $messageId
 
   let res = await makeRequest(endpoint % b.token, data)
   result = res.bval


### PR DESCRIPTION
Adds endpoints to edit and delete bot messages.
The API will either return the edited message, or `true` if the message was sent inline via the bot.
To avoid some messy type like `Future[(bool, Option[Message])]`, I went for `Future[Option(Message)]`. If they fail, they're going to raise an exception anyway, so including the `true` seems unnecessary.
I also edited `editMessageMedia` to reflect this, so it now returns `Option[Message]` instead of `bool`.

I upped the version number to 0.5.0 since this is a breaking change. 