### PR TITLE
Add macro to generate missing InputMedia functions

### DIFF
--- a/telebot/inputmedia.nim
+++ b/telebot/inputmedia.nim
@@ -1,4 +1,4 @@
-import types, json, strutils, utils, options
+import types, json, strutils, utils, options, macros
 
 proc `$`*(m: InputMedia): string =
     result = ""
@@ -18,20 +18,9 @@ proc `$`*(m: InputMedia): string =
     elif m of InputMediaDocument:
         var document = InputMediaDocument(m)
         marshal(document[], result)
-proc newInputMediaPhoto*(media: string, caption = "", parseMode = ""): InputMediaPhoto =
-    new(result)
-    result.kind = "photo"
-    result.media = media
-    if caption.len > 0:
-        result.caption = some(caption)
-    if parseMode.len > 0:
-        result.parseMode = some(parseMode)
 
-proc newInputMediaVideo*(media: string, caption = "", parseMode = ""): InputMediaVideo =
-    new(result)
-    result.kind = "video"
-    result.media = media
-    if caption.len > 0:
-        result.caption = some(caption)
-    if parseMode.len > 0:
-        result.parseMode = some(parseMode)
+genInputMedia("Photo")
+genInputMedia("Video")
+genInputMedia("Animation")
+genInputMedia("Audio")
+genInputMedia("Document")

--- a/telebot/utils.nim
+++ b/telebot/utils.nim
@@ -210,8 +210,23 @@ proc uploadInputMedia*(p: var MultipartData, m: InputMedia) =
     m.thumb = some("attach://" & name)
     p.addFiles({name: m.media[7..m.media.len-1]})
 
+macro genInputMedia*(mediaType: string): untyped =
+  let
+    media = $mediaType
+    kind = media.toLowerAscii()
+    objName = "InputMedia" & media
+    funcName = "new" & objName
 
-
+  result = parseStmt("""
+proc $1*(media: string; caption=""; parseMode=""): $2 =
+  new(result)
+  result.kind = "$3"
+  result.media = media
+  if caption.len > 0:
+    result.caption = some(caption)
+  if parseMode.len > 0:
+    result.parseMode = some(parseMode)
+""".format(funcName, objName, kind))
 
 macro magic*(head, body: untyped): untyped =
   result = newStmtList()


### PR DESCRIPTION
This generates missing functions to create InputMedia objects.
The usage of the new ones is the same as the old ones.
```nim
let 
  p = newInputMediaPhoto(fileId)
  a = newinputMediaAnimation(fileId, caption="Text")
```