### PR TITLE
Restore async concurrency

### DIFF
--- a/telebot.nim
+++ b/telebot.nim
@@ -3,23 +3,14 @@ import tables, httpclient
 import telebot/[types, keyboard, webhook, inputmedia, helpers]
 export types, webhook, keyboard, inputmedia, helpers
 
-proc initHttpClient(b: Telebot, proxy: Proxy = nil) {.inline.} =
-  b.httpClient = newAsyncHttpClient(userAgent="telebot.nim/0.5.7", proxy=proxy)
-  b.httpClient.headers = newHttpHeaders({
-    "Connection": "Keep-Alive",
-    "Keep-Alive": "timeout=50"
-  })
-
 proc setProxy*(b: Telebot, url: string, auth = "") {.inline.} =
-  b.initHttpClient(newProxy(url, auth))
+  b.proxy = newProxy(url, auth)
 
 proc newTeleBot*(token: string): TeleBot =
   ## Init new Telegram Bot instance
   new(result)
   result.token = token
   result.commandCallbacks = newTable[string, seq[CommandCallback]]()
-
-  result.initHttpClient()
 
 include telebot/api
 include telebot/events

--- a/telebot.nimble
+++ b/telebot.nimble
@@ -1,4 +1,4 @@
-version       = "0.5.8"
+version       = "0.5.9"
 author        = "Huy Doan"
 description   = "Async Telegram Bot API Client"
 license       = "MIT"

--- a/telebot/types.nim
+++ b/telebot/types.nim
@@ -10,12 +10,12 @@ type
 
   TeleBot* = ref object of TelegramObject
     token*: string
-    httpClient*: AsyncHttpClient
     lastUpdateId*: BiggestInt
     updateCallbacks*: seq[UpdateCallBack]
     commandCallbacks*: TableRef[string, seq[CommandCallback]]
     catchallCommandCallback*: CatchallCommandCallback
     inlineQueryCallbacks*: seq[InlineQueryCallback]
+    proxy*: Proxy
 
   CatchallCommand* = object of TelegramObject
     command*: string


### PR DESCRIPTION
Thank you for the recent updates, good to see some progress. From 22ba9b9 and onwards though, my bots broke. After some changes to my code it started working again, but I noticed all updates were blocking, for example by calling `await sleepAsync(1000)` in a callback blocks other updates.

I found out this is due to using a single AsyncHttpClient, which to my knowledge cannot actually handle multiple requests asynchronously. I rolled back that change and made some modifications to support your new proxy changes.

This is still a bit slower than using the same http client at all times but I can't see any way to do that concurrently. Let me know what you think.