### PR TITLE
Fix cleanUpdates skipping first message

### DIFF
--- a/telebot/api.nim
+++ b/telebot/api.nim
@@ -678,10 +678,9 @@ proc handleUpdate*(b: TeleBot, update: Update) {.async.} =
       await cb(b, update)
 
 proc cleanUpdates*(b: TeleBot) {.async.} =
-  var updates = await b.getUpdates()
+  var updates = await b.getUpdates(timeout=0)
   while updates.len >= 100:
     updates = await b.getUpdates()
-
 
 proc loop(b: TeleBot, timeout = 50, offset, limit = 0) {.async.} =
   while true:


### PR DESCRIPTION
Forgot to set the timeout to 0 in cleanUpdates, resulting in the first message (within the timout of course) getting skipped.