### PR TITLE
Making requestPoll field optional for KeyboardButton

### DIFF
--- a/src/telebot/private/types.nim
+++ b/src/telebot/private/types.nim
@@ -190,7 +190,7 @@ type
     text*: string
     requestContact*: Option[bool]
     requestLocation*: Option[bool]
-    requestPoll*: KeyboardButtonPollType
+    requestPoll*: Option[KeyboardButtonPollType]
 
   InlineKeyboardButton* = object
     text*: string


### PR DESCRIPTION
In case requestPoll field was not initialized Illegal storage access error was happening:
-------------------------------------------------------------------------------------------------------
Traceback (most recent call last)
/home/watchcat/fun/afvalbot/src/afvalbot.nim(107) afvalbot
/home/watchcat/.nimble/pkgs/telebot-1.0.1/telebot/private/api.nim(991) poll
/home/watchcat/.choosenim/toolchains/nim-1.2.0/lib/pure/asyncdispatch.nim(1886) waitFor
/home/watchcat/.choosenim/toolchains/nim-1.2.0/lib/pure/asyncdispatch.nim(1576) poll
/home/watchcat/.choosenim/toolchains/nim-1.2.0/lib/pure/asyncdispatch.nim(1340) runOnce
/home/watchcat/.choosenim/toolchains/nim-1.2.0/lib/pure/asyncdispatch.nim(210) processPendingCallbacks
/home/watchcat/.choosenim/toolchains/nim-1.2.0/lib/pure/asyncmacro.nim(34) loopNimAsyncContinue
/home/watchcat/.nimble/pkgs/telebot-1.0.1/telebot/private/api.nim(986) loopIter
/home/watchcat/.choosenim/toolchains/nim-1.2.0/lib/pure/asyncmacro.nim(319) handleUpdate
/home/watchcat/.choosenim/toolchains/nim-1.2.0/lib/pure/asyncmacro.nim(34) handleUpdateNimAsyncContinue
/home/watchcat/.nimble/pkgs/telebot-1.0.1/telebot/private/api.nim(959) handleUpdateIter
/home/watchcat/.choosenim/toolchains/nim-1.2.0/lib/pure/asyncmacro.nim(319) startHandler
/home/watchcat/.choosenim/toolchains/nim-1.2.0/lib/pure/asyncmacro.nim(34) startHandlerNimAsyncContinue
/home/watchcat/fun/afvalbot/src/afvalbot.nim(65) startHandlerIter
/home/watchcat/.choosenim/toolchains/nim-1.2.0/lib/pure/asyncmacro.nim(319) sendMessage
/home/watchcat/.choosenim/toolchains/nim-1.2.0/lib/pure/asyncmacro.nim(34) sendMessageNimAsyncContinue
/home/watchcat/.nimble/pkgs/telebot-1.0.1/telebot/private/api.nim(21) sendMessageIter
/home/watchcat/.nimble/pkgs/telebot-1.0.1/telebot/private/keyboard.nim(36) $
/home/watchcat/.nimble/pkgs/telebot-1.0.1/telebot/private/utils.nim(125) marshal
/home/watchcat/.nimble/pkgs/telebot-1.0.1/telebot/private/utils.nim(120) marshal
/home/watchcat/.nimble/pkgs/telebot-1.0.1/telebot/private/utils.nim(129) marshal
/home/watchcat/.nimble/pkgs/telebot-1.0.1/telebot/private/utils.nim(129) marshal
/home/watchcat/.nimble/pkgs/telebot-1.0.1/telebot/private/utils.nim(120) marshal
/home/watchcat/.nimble/pkgs/telebot-1.0.1/telebot/private/utils.nim(125) marshal
/home/watchcat/.nimble/pkgs/telebot-1.0.1/telebot/private/utils.nim(120) marshal
SIGSEGV: Illegal storage access. (Attempt to read from nil?)a