### PR TITLE
Add default arg for entity argument in sendMessage proc to fix backward compatibility

### DIFF
--- a/src/telebot/private/api.nim
+++ b/src/telebot/private/api.nim
@@ -2,7 +2,7 @@ import httpclient, sam, asyncdispatch, utils, strutils, options, strtabs
 from tables import hasKey, `[]`
 import types, keyboard
 
-proc sendMessage*(b: TeleBot, chatId: int64, text: string, parseMode = "", entities: seq[MessageEntity],
+proc sendMessage*(b: TeleBot, chatId: int64, text: string, parseMode = "", entities: seq[MessageEntity] = @[],
                   disableWebPagePreview = false, disableNotification = false, replyToMessageId = 0,
                   allowSendingWithoutReply = false, replyMarkup: KeyboardMarkup = nil): Future[Message] {.async.} =
   END_POINT("sendMessage")


### PR DESCRIPTION
Hi! I noticed that with recent API bump to 5.0 the backward compatibility was lost due `sendMessage` proc missing default value for newly introduced argument `entities`. I added empty seq and it seems work fine now.