### PR TITLE
Don't parse command entity as command if it's not at the beginning of…

### DIFF
--- a/src/telebot/private/utils.nim
+++ b/src/telebot/private/utils.nim
@@ -39,7 +39,7 @@ template hasCommand*(update: Update, username: string): bool =
     let
       entities = message.entities.get()
       messageText = message.text.get()
-    if entities[0].kind == "bot_command":
+    if entities[0].kind == "bot_command" and entities[0].offset == 0:
       let
         offset = entities[0].offset
         length = entities[0].length


### PR DESCRIPTION
If command isn't at the beginning of message, for example
```something /here```
it should NOT be parsed as command