### PR TITLE
Fix library when using 32-bit architectures

### DIFF
--- a/src/telebot/private/utils.nim
+++ b/src/telebot/private/utils.nim
@@ -137,7 +137,7 @@ proc unmarshal*(n: JsonNode, T: typedesc): T =
     for i in 0..<n.len:
       result[i] = unmarshal(n[i], result[0].type)
   elif result is SomeInteger:
-    result = cast[result.type](n.getInt)
+    result = type(result)(n.getBiggestInt)
   elif result is SomeFloat:
     result = n.getFloat
   elif result is string:


### PR DESCRIPTION
Before this change, telebot would crash because in `unmarshal` in utils it's using `getInt` which uses architecture's native int size, but Telegram has some types that are 64-bit, so the code needs to use `getBiggestInt` instead.

Also changed the code so that it does a type conversion instead of a cast which is safer.

I'm not sure if there are any other bugs regarding 32-bit compatibility, but with this one the basic echo bot at least works fine.
