### PR TITLE
Fix getting procName in devel

### DIFF
--- a/src/telebot/private/utils.nim
+++ b/src/telebot/private/utils.nim
@@ -13,7 +13,9 @@ template procName*: string =
     var internalProcName {.exportc, inject.}: cstring
     {.emit: "`internalProcName` = __func__;".}
     var realProcName {.inject.}: string
-    discard parseUntil($internalProcName, realProcName, "Iter_")
+    const newAsyncSuffix = "X20X28AsyncX29" # " (Async)" in ASCII
+    let suffix = if newAsyncSuffix in $internalProcName: newAsyncSuffix else: "Iter_"
+    discard parseUntil($internalProcName, realProcName, suffix)
   realProcName
 
 template hasCommand*(update: Update, username: string): bool =


### PR DESCRIPTION
Async procs have different names in devel (It makes stack traces easier to read) which broke the parsing code for `procName`.

Now selects correct suffix for an async proc and uses that for `parseUntil`