### PR TITLE
Check if update actually contains entities

### DIFF
--- a/src/telebot/private/utils.nim
+++ b/src/telebot/private/utils.nim
@@ -36,7 +36,7 @@ template hasCommand*(update: Update, username: string): bool =
   else:
     result = false
 
-  if hasMessage and message.entities.isSome:
+  if hasMessage and message.entities.isSome and message.entities.get.len > 0:
     let
       entities = message.entities.get()
       messageText = message.text.get()


### PR DESCRIPTION
Apparently, Telegram may send an update containing an empty array on the `entities` parameter. Telebot currently doesn't check the array's length and will throw an exception when this is the case. 

I have added a very simple check to the parameter in order to not make the entire bot crash.