### PR TITLE
Change `InlineQueryResult.replyMarkup` type to `InlineKeyboardMarkup`

### DIFF
--- a/src/telebot/private/types.nim
+++ b/src/telebot/private/types.nim
@@ -775,7 +775,7 @@ type
     id*: string
     captionEntities*: Option[seq[MessageEntity]]
     inputMessageContent*: Option[InputMessageContent]
-    replyMarkup*: Option[KeyboardMarkup]
+    replyMarkup*: Option[InlineKeyboardMarkup]
 
   InlineQueryResultWithThumb* = object of InlineQueryResult
     thumbnailUrl*: Option[string]


### PR DESCRIPTION
Change `types.InlineQueryResult.replyMarkup` type from `types.KeyboardMarkup` to `types.InlineKeyboardMarkup`

`types.InlineQueryResult.replyMarkup` doesn't compiles with `some newInlineKeyboardMarkup(...)` and `some cast[KeyboardMarkup](newInlineKeyboardMarkup(...))` compiles but the data is lost.

doesn't compiles
```nim
res.replyMarkup = some newInlineKeyboardMarkup(@[
  initInlineKeyboardButton("Test", "url")
])
```

loses the data
```nim
res.replyMarkup = some cast[KeyboardMarkup](newInlineKeyboardMarkup(@[
  initInlineKeyboardButton("Test", "url")
]))
```