### PR TITLE
Edit serialization of ReplyKeyboardRemove.

### DIFF
--- a/src/telebot/private/keyboard.nim
+++ b/src/telebot/private/keyboard.nim
@@ -61,7 +61,7 @@ proc `$`*(k: KeyboardMarkup): string =
   of kReplyKeyboardMarkup:
     marshal(ReplyKeyboardMarkup(k), result)
   of kReplyKeyboardRemove:
-    let kb = ReplyKeyboardMarkup(k)
+    let kb = ReplyKeyboardRemove(k)
     if kb.selective:
       result = "{\"remove_keyboard\": true, \"selective\": true}"
     else:


### PR DESCRIPTION
I tried to remove a reply keyboard and got an error:
```
...
  /home/ruincorn/.nimble/pkgs2/telebot-2025.02.22-37dee6df650661970c1442e1b1f815f0f33e7687/telebot/private/utils.nim(250) addData
  /home/ruincorn/.nimble/pkgs2/telebot-2025.02.22-37dee6df650661970c1442e1b1f815f0f33e7687/telebot/private/keyboard.nim(64) $
  /home/ruincorn/.choosenim/toolchains/nim-2.2.6/lib/system/fatal.nim(53) sysFatal
Exception message: invalid object conversion
 [ObjectConversionDefect]
```

Here is my code:
```nim
discard await bot.sendMessage(chatId, "Removing your keyboard", replyMarkup = newReplyKeyboardRemove())
```

As I can observe, the problem was here (see changes).
After this change, everything worked fine.

I used latest version (2025.02.22)
```
requires "telebot"
```
Tell me if I'm trying to merge this into the wrong place.
